### PR TITLE
Refactor radar chart generation and add unit tests

### DIFF
--- a/src/utils/shooting_visualizations.py
+++ b/src/utils/shooting_visualizations.py
@@ -1,6 +1,8 @@
 import os
+import warnings # Added for deprecation warnings
 import pandas as pd
 import numpy as np
+from src.utils.visualization import plot_radar_chart
 import matplotlib.pyplot as plt
 import seaborn as sns
 from typing import Dict, List, Optional, Tuple, Union
@@ -161,7 +163,8 @@ def create_shooting_profile_radar(
     min_90s: float = 5
 ) -> plt.Figure:
     """
-    Create a radar chart comparing shooting profiles of selected players.
+    DEPRECATED: Create a radar chart comparing shooting profiles of selected players.
+    Use plot_radar_chart from src.utils.visualization for a more general and updated solution.
 
     Args:
         df: DataFrame with shooting statistics
@@ -172,6 +175,12 @@ def create_shooting_profile_radar(
     Returns:
         matplotlib Figure object
     """
+    warnings.warn(
+        "create_shooting_profile_radar is deprecated and will be removed in a future version. "
+        "Use plot_radar_chart from src.utils.visualization instead.",
+        FutureWarning,
+        stacklevel=2 # Points the warning to the caller of this function
+    )
     # Filter data for selected players and minimum minutes
     plot_df = df[(df["Player"].isin(players)) & (df["90s"] >= min_90s)].copy()
 
@@ -372,18 +381,100 @@ def create_shooting_metrics_dashboard(
 
     # 4. Radar comparison of top scorers
     try:
-        # Get top 5 goal scorers
-        top_scorers = shooting_df.sort_values("Gls", ascending=False).head(5)["Player"].tolist()
+        top_scorers_names = shooting_df.sort_values("Gls", ascending=False).head(5)["Player"].tolist()
 
-        if len(top_scorers) >= 3:  # Need at least 3 players for a meaningful radar
-            output_file = os.path.join(output_dir, "top_scorers_radar.png")
-            create_shooting_profile_radar(
-                shooting_df,
-                players=top_scorers[:5],  # Limit to 5 players
-                output_file=output_file,
-                min_90s=min_90s
-            )
-            created_files.append(output_file)
+        if len(top_scorers_names) < 3: # Original check: Need at least 3 players for a meaningful radar
+            print(f"Not enough top scorers ({len(top_scorers_names)}) to generate a meaningful radar chart. Skipping.")
+        else:
+            # Filter the DataFrame for the selected players and minimum 90s played
+            plot_df = shooting_df[
+                (shooting_df["Player"].isin(top_scorers_names)) &
+                (shooting_df["90s"] >= min_90s)
+            ].copy() # Use .copy() to avoid SettingWithCopyWarning
+
+            if plot_df.empty:
+                print(f"No players found matching criteria for shooting radar chart (top scorers list: {top_scorers_names}, min_90s={min_90s}). Skipping.")
+            # Check if enough unique players remain after filtering. plot_radar_chart needs at least one.
+            elif len(plot_df["Player"].unique()) < 1: 
+                print(f"Not enough unique players ({len(plot_df['Player'].unique())}) after min_90s filter for shooting radar. Skipping.")
+            else:
+                # Define the metrics for the radar chart.
+                metric_columns = ["Sh/90", "SoT%", "G/Sh", "Dist", "npxG/Sh", "G-xG"]
+                
+                # Calculate missing metrics if they are not already in the DataFrame.
+                # This includes handling potential division by zero.
+                if "90s" in plot_df.columns and "Sh" in plot_df.columns:
+                    if "Sh/90" not in plot_df.columns:
+                        plot_df["Sh/90"] = np.nan # Initialize column
+                        # Calculate Sh/90 only for rows where 90s > small epsilon to avoid division by zero/very small numbers
+                        valid_90s_mask = plot_df["90s"] > 1e-6 
+                        plot_df.loc[valid_90s_mask, "Sh/90"] = plot_df.loc[valid_90s_mask, "Sh"] / plot_df.loc[valid_90s_mask, "90s"]
+                
+                if "Sh" in plot_df.columns:
+                    if "G/Sh" not in plot_df.columns and "Gls" in plot_df.columns:
+                        plot_df["G/Sh"] = np.nan # Initialize column
+                        valid_sh_mask = plot_df["Sh"] > 0 # Shots must be positive integer
+                        plot_df.loc[valid_sh_mask, "G/Sh"] = plot_df.loc[valid_sh_mask, "Gls"] / plot_df.loc[valid_sh_mask, "Sh"]
+                    
+                    if "npxG/Sh" not in plot_df.columns and "npxG" in plot_df.columns:
+                        plot_df["npxG/Sh"] = np.nan # Initialize column
+                        valid_sh_mask = plot_df["Sh"] > 0
+                        plot_df.loc[valid_sh_mask, "npxG/Sh"] = plot_df.loc[valid_sh_mask, "npxG"] / plot_df.loc[valid_sh_mask, "Sh"]
+
+                if "G-xG" not in plot_df.columns and "Gls" in plot_df.columns and "xG" in plot_df.columns:
+                    plot_df["G-xG"] = plot_df["Gls"] - plot_df["xG"]
+
+                # Filter out metrics that are not in plot_df or are all NaN after calculation.
+                # These are the metrics that will actually be plotted.
+                available_metrics = [
+                    m for m in metric_columns 
+                    if m in plot_df.columns and plot_df[m].notna().any()
+                ]
+
+                if len(available_metrics) < 3:
+                    print(f"Not enough available and valid metrics ({len(available_metrics)}) for shooting radar chart. Need at least 3. Available: {available_metrics}. Skipping.")
+                else:
+                    # Drop rows that have NaN for any of the available_metrics to be plotted.
+                    # This ensures that each player passed to plot_radar_chart has data for all axes.
+                    final_plot_df = plot_df.dropna(subset=available_metrics).copy() 
+                    
+                    # Get the list of player names from the filtered and NaN-dropped DataFrame.
+                    entity_names_list = final_plot_df["Player"].unique().tolist() # Use unique() to be safe.
+                    
+                    if final_plot_df.empty or not entity_names_list:
+                         print(f"No players remaining with complete data for available metrics ({available_metrics}) after NaN drop. Skipping radar chart.")
+                    elif len(entity_names_list) < 1: # Double check, though covered by plot_df.empty and unique list check
+                         print(f"Not enough players ({len(entity_names_list)}) for radar chart after processing NaNs. Skipping.")
+                    else:
+                        # Prepare data for plot_radar_chart:
+                        # 1. Create a list of single-row DataFrames, one for each player.
+                        # 2. Create a list of player names corresponding to these DataFrames.
+                        data_frames_list = []
+                        for player_name in entity_names_list: # Iterate based on unique players in final_plot_df
+                            player_specific_data = final_plot_df[final_plot_df["Player"] == player_name]
+                            # Ensure we take only the first row if somehow duplicates exist (should not with unique names)
+                            # And ensure columns are in the correct 'available_metrics' order.
+                            player_data_df = pd.DataFrame(player_specific_data[available_metrics].iloc[[0]].values, columns=available_metrics)
+                            data_frames_list.append(player_data_df)
+                        
+                        if not data_frames_list: # Should be caught by earlier checks on entity_names_list
+                             print(f"Dataframe list for radar chart is empty despite having entity names. Skipping.")
+                        else:
+                            output_file = os.path.join(output_dir, "top_scorers_radar.png")
+                            # Define normalization specifications, e.g., 'Dist' where lower is better.
+                            normalization_specs = {'Dist': 'inverted'} 
+
+                            # Call the generic radar chart plotting function.
+                            plot_radar_chart(
+                                data_frames=data_frames_list,
+                                metric_columns=available_metrics, # Use the validated list of metrics
+                                entity_names=entity_names_list,
+                                title="Shooting Profile Comparison", # Hardcoded title from old function
+                                normalize=True, # plot_radar_chart defaults to True, this is for clarity
+                                normalization_specs=normalization_specs,
+                                output_file=output_file
+                            )
+                            created_files.append(output_file)
     except Exception as e:
         print(f"Error creating shooting profile radar: {str(e)}")
 

--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -1,5 +1,5 @@
 import os
-import warnings # Added for deprecation warnings
+import warnings
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt

--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -1,4 +1,5 @@
 import os
+import warnings # Added for deprecation warnings
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -15,7 +16,8 @@ def create_radar_comparison(
     normalize: bool = True
 ) -> plt.Figure:
     """
-    Create a radar chart comparing multiple players across different metrics.
+    DEPRECATED: Create a radar chart comparing multiple players across different metrics. 
+    Use plot_radar_chart instead for more flexibility and consistent normalization.
 
     Parameters:
     -----------
@@ -31,6 +33,12 @@ def create_radar_comparison(
     --------
     matplotlib Figure object
     """
+    warnings.warn(
+        "create_radar_comparison is deprecated and will be removed in a future version. "
+        "Use plot_radar_chart instead.",
+        FutureWarning,
+        stacklevel=2  # Ensures the warning points to the caller of this function
+    )
     # Select top players and required columns
     players_df = df.head(max_players).copy()
 
@@ -331,19 +339,66 @@ def create_dashboard(
 
     # 1. Versatility radar chart
     if "versatile_players" in results and not results["versatile_players"].empty:
-        versatile_df = results["versatile_players"].head(5)
-        metrics = ["passing_score", "possession_score", "defensive_score"]
-        if "shooting_score" in versatile_df.columns:
-            metrics.append("shooting_score")
+        versatile_df = results["versatile_players"].head(5) # This selects top 5 players as before
+        
+        # Define metrics for the radar chart, equivalent to the old 'metrics' list
+        metric_columns_for_radar = ["passing_score", "possession_score", "defensive_score"]
+        if "shooting_score" in versatile_df.columns: # Check if optional metric is present
+            metric_columns_for_radar.append("shooting_score")
+        
+        # Ensure all selected metrics are actually present in the DataFrame columns
+        # This prevents errors if a defined metric is missing from versatile_df
+        metric_columns_for_radar = [m for m in metric_columns_for_radar if m in versatile_df.columns]
 
-        output_file = os.path.join(output_dir, f"{prefix}versatility_radar.png")
-        create_radar_comparison(
-            versatile_df,
-            metrics=metrics,
-            title="Top Players by Versatility",
-            output_file=output_file
-        )
-        created_files.append(output_file)
+        # Determine the player name column. The old call didn't specify player_column,
+        # so create_radar_comparison would have used its default "Player".
+        player_name_col = "Player" 
+        
+        if not metric_columns_for_radar:
+            print(f"Warning: No valid metrics found for versatility radar chart ({prefix}versatility_radar.png). Skipping.")
+        elif player_name_col not in versatile_df.columns:
+            # If "Player" column is not found, try "Name" as a common alternative.
+            if "Name" in versatile_df.columns:
+                player_name_col = "Name"
+            else:
+                print(f"Warning: Player column '{player_name_col}' or 'Name' not found in versatile_players DataFrame for {prefix}versatility_radar.png. Skipping chart.")
+                # To prevent further errors, we effectively skip this chart if no player name column is found.
+                # This is done by not proceeding to the data_frames_list creation.
+        
+        # Proceed only if we have metrics and a valid player name column
+        if metric_columns_for_radar and player_name_col in versatile_df.columns:
+            # Prepare data for plot_radar_chart:
+            # 1. Create a list of single-row DataFrames, one for each player, containing the selected metrics.
+            # 2. Create a list of player names corresponding to these DataFrames.
+            data_frames_list = []
+            entity_names_list = []
+
+            for _, row in versatile_df.iterrows():
+                # Extract the player's data for the specified radar metrics.
+                player_metrics_data = row[metric_columns_for_radar]
+                # Create a single-row DataFrame. Using .values and specifying columns ensures correct structure.
+                player_data_df = pd.DataFrame([player_metrics_data.values], columns=metric_columns_for_radar)
+                data_frames_list.append(player_data_df)
+                entity_names_list.append(row[player_name_col])
+            
+            if data_frames_list: # Ensure data was actually prepared
+                output_file = os.path.join(output_dir, f"{prefix}versatility_radar.png")
+                
+                # Call the new plot_radar_chart function
+                plot_radar_chart(
+                    data_frames=data_frames_list,
+                    metric_columns=metric_columns_for_radar, 
+                    entity_names=entity_names_list,
+                    title="Top Players by Versatility", # Same title as before
+                    output_file=output_file
+                    # normalize=True is the default in plot_radar_chart.
+                    # create_radar_comparison also defaulted to normalize=True.
+                )
+                created_files.append(output_file)
+            else:
+                # This condition might be hit if versatile_df was empty or became empty after filtering,
+                # though the initial checks should largely prevent this.
+                print(f"Warning: No data to plot for versatility radar chart ({prefix}versatility_radar.png) after processing. Skipping.")
 
     # 2. Progressive actions comparison
     prog_metrics = ["overall_progressors", "top_carriers", "top_passers"]
@@ -437,3 +492,229 @@ def create_dashboard(
             created_files.append(output_file)
 
     return created_files
+
+
+def plot_radar_chart(
+    data_frames: List[pd.DataFrame],
+    metric_columns: List[str],
+    entity_names: List[str],
+    title: str = "Radar Chart Comparison",
+    normalize: bool = True,
+    normalization_specs: Optional[Dict[str, str]] = None,
+    fig_size: Tuple[int, int] = (10, 10),
+    colors: Optional[List[str]] = None,
+    line_styles: Optional[List[str]] = None,
+    line_widths: Optional[List[float]] = None,
+    fill_alphas: Optional[List[float]] = None,
+    metric_labels_override: Optional[Dict[str, str]] = None,
+    legend_kwargs: Optional[Dict] = None,
+    output_file: Optional[str] = None,
+    dpi: int = 300,
+    ax: Optional[plt.Axes] = None
+) -> plt.Figure:
+    """
+    Generate a radar chart comparing multiple entities across specified metrics.
+
+    This function allows for flexible customization of the radar chart, including normalization options
+    per metric (e.g., inverting scales for metrics where lower is better).
+
+    Parameters:
+    -----------
+    data_frames : List[pd.DataFrame]
+        A list of pandas DataFrames. Each DataFrame represents one entity (e.g., player, team)
+        and *must* contain exactly one row of data. The columns of these DataFrames should
+        correspond to the metrics being plotted.
+        Example: `[pd.DataFrame({'MetricA': [10], 'MetricB': [20]}), pd.DataFrame({'MetricA': [15], 'MetricB': [25]})]`
+    metric_columns : List[str]
+        A list of strings specifying the column names from the DataFrames in `data_frames`
+        to be used as axes (metrics) for the radar chart. The order in this list determines
+        the order of axes on the chart.
+    entity_names : List[str]
+        A list of strings representing the names of the entities being compared. The order of
+        names in this list must correspond to the order of DataFrames in `data_frames`.
+        These names will be used in the legend.
+    title : str, optional
+        The title for the radar chart. Defaults to "Radar Chart Comparison".
+    normalize : bool, optional
+        If True (default), metric values are normalized to a 0-1 scale across all entities for each metric.
+        This is crucial when comparing metrics with different units or scales. Normalization is
+        performed by scaling based on the minimum and maximum values found for that metric
+        across *all* provided `data_frames`. If False, raw values are used (not recommended
+        for metrics with vastly different scales).
+    normalization_specs : Optional[Dict[str, str]], optional
+        A dictionary to specify custom normalization behavior for individual metrics. This is
+        applied only if `normalize` is True.
+        Keys should be metric column names (from `metric_columns`).
+        Values should be strings indicating the normalization type:
+        - 'standard': Standard min-max normalization: `(value - min) / (max - min)`. This is the
+                      default for metrics not specified or if `normalization_specs` is None.
+        - 'inverted': Inverted min-max normalization: `1 - ((value - min) / (max - min))`.
+                      Useful for metrics where lower values are better (e.g., rank, distance error).
+        Example: `{'Rank': 'inverted', 'Score': 'standard'}`. Defaults to None.
+    fig_size : Tuple[int, int], optional
+        Tuple specifying the figure size (width, height) in inches if a new figure is created
+        (i.e., if `ax` is None). Defaults to (10, 10).
+    colors : Optional[List[str]], optional
+        A list of color strings for each entity's plot. If None, uses Matplotlib's default
+        color cycle. The list length should match the number of entities.
+    line_styles : Optional[List[str]], optional
+        A list of line style strings (e.g., '-', '--', ':') for each entity's plot. If None,
+        uses a solid line for all. The list length should match the number of entities.
+    line_widths : Optional[List[float]], optional
+        A list of line widths for each entity's plot. If None, uses a default width (e.g., 1.5).
+        The list length should match the number of entities.
+    fill_alphas : Optional[List[float]], optional
+        A list of alpha (transparency) values (0.0 to 1.0) for the fill of each entity's plot.
+        If None, uses a default alpha (e.g., 0.1). The list length should match the number of entities.
+    metric_labels_override : Optional[Dict[str, str]], optional
+        A dictionary to override the display names for metrics on the chart axes.
+        Keys should be metric column names, and values are the desired display names.
+        Example: `{'shots_pg': 'Shots per Game'}`. Defaults to None (uses title-cased column names).
+    legend_kwargs : Optional[Dict], optional
+        A dictionary of keyword arguments to be passed to `ax.legend()`.
+        Example: `{'loc': 'lower center', 'ncol': 3}`. Defaults to a standard legend configuration.
+    output_file : Optional[str], optional
+        The file path to save the figure. If None, the figure is not saved. Defaults to None.
+    dpi : int, optional
+        Dots per inch for the saved figure. Used if `output_file` is provided. Defaults to 300.
+    ax : Optional[plt.Axes], optional
+        A Matplotlib Axes object with a polar projection to plot on. If None (default),
+        a new figure and polar axes are created.
+
+    Returns:
+    --------
+    plt.Figure
+        The Matplotlib Figure object containing the radar chart.
+
+    Raises:
+    -------
+    ValueError
+        If input parameters are inconsistent (e.g., mismatched lengths of `data_frames` and
+        `entity_names`; DataFrames with incorrect shape (not single-row); missing `metric_columns`
+        in any DataFrame; or if a provided `ax` is not a Matplotlib polar Axes object).
+    """
+    # Input Validation
+    if len(data_frames) != len(entity_names):
+        raise ValueError("Length of data_frames must match length of entity_names.")
+    if colors and len(colors) != len(data_frames):
+        raise ValueError("Length of colors must match length of data_frames if provided.")
+    if line_styles and len(line_styles) != len(data_frames):
+        raise ValueError("Length of line_styles must match length of data_frames if provided.")
+    if line_widths and len(line_widths) != len(data_frames):
+        raise ValueError("Length of line_widths must match length of data_frames if provided.")
+    if fill_alphas and len(fill_alphas) != len(data_frames):
+        raise ValueError("Length of fill_alphas must match length of data_frames if provided.")
+
+    for i, df_entity in enumerate(data_frames): # Renamed df to df_entity for clarity
+        if not isinstance(df_entity, pd.DataFrame):
+            raise ValueError(f"Item at index {i} in data_frames is not a pandas DataFrame.")
+        if df_entity.shape[0] != 1:
+            raise ValueError(f"DataFrame for entity '{entity_names[i]}' must have exactly one row. Found shape {df_entity.shape}.")
+        for metric in metric_columns:
+            if metric not in df_entity.columns:
+                raise ValueError(f"Metric '{metric}' not found in DataFrame for entity '{entity_names[i]}'. Available columns: {list(df_entity.columns)}")
+
+    # Figure and Axes
+    if ax:
+        if not hasattr(ax, 'name') or ax.name != 'polar': # More robust check for polar axes
+            raise ValueError("Provided 'ax' must be a Matplotlib polar Axes object.")
+        fig = ax.get_figure()
+    else:
+        fig, ax = plt.subplots(figsize=fig_size, subplot_kw=dict(polar=True))
+
+    num_metrics = len(metric_columns)
+    processed_values_all_entities = []
+
+    # Data Preparation
+    if normalize:
+        metric_data_for_scaling = {metric: [] for metric in metric_columns}
+        for df_entity in data_frames:
+            for metric in metric_columns:
+                metric_data_for_scaling[metric].append(df_entity[metric].iloc[0])
+        
+        min_max_per_metric = {}
+        for metric, values in metric_data_for_scaling.items():
+            # Ensure values are numeric before min/max, handle potential non-numeric data if necessary
+            numeric_values = pd.to_numeric(values, errors='coerce')
+            numeric_values = numeric_values[~np.isnan(numeric_values)] # Remove NaNs that were non-numeric
+            if len(numeric_values) == 0: # All values were non-numeric or NaN
+                 min_val, max_val = 0, 1 # Default scaling if no valid numeric data
+            else:
+                min_val = np.min(numeric_values)
+                max_val = np.max(numeric_values)
+            min_max_per_metric[metric] = (min_val, max_val)
+
+    for df_entity in data_frames:
+        entity_values = []
+        for metric in metric_columns:
+            value = df_entity[metric].iloc[0]
+            if pd.isna(value): # Handle NaN values before normalization
+                entity_values.append(0.0) # Or some other placeholder like np.nan then handle in plotting
+                continue
+
+            if normalize:
+                min_val, max_val = min_max_per_metric[metric]
+                
+                if max_val == min_val:
+                    normalized_value = 0.5 
+                else:
+                    normalized_value = (value - min_val) / (max_val - min_val)
+
+                if normalization_specs and metric in normalization_specs:
+                    if normalization_specs[metric] == 'inverted':
+                        normalized_value = 1 - normalized_value
+                    # elif normalization_specs[metric] != 'standard':
+                        # Can add warning or error for unknown spec, or just default to standard
+                entity_values.append(normalized_value)
+            else:
+                entity_values.append(value)
+        processed_values_all_entities.append(entity_values)
+
+    # Plotting
+    angles = np.linspace(0, 2 * np.pi, num_metrics, endpoint=False).tolist()
+    angles += angles[:1]
+
+    # Default styling
+    if colors is None:
+        prop_cycle = plt.rcParams['axes.prop_cycle']
+        default_colors = prop_cycle.by_key()['color']
+        colors = [default_colors[i % len(default_colors)] for i in range(len(data_frames))]
+    
+    if line_styles is None: line_styles = ['-'] * len(data_frames)
+    if line_widths is None: line_widths = [1.5] * len(data_frames)
+    if fill_alphas is None: fill_alphas = [0.1] * len(data_frames)
+
+    for i, values in enumerate(processed_values_all_entities):
+        plot_values = values + values[:1]
+        # Ensure no NaNs are passed to plot, replace with a value (e.g., 0) or skip point
+        plot_values_cleaned = [0 if pd.isna(v) else v for v in plot_values]
+
+        ax.plot(angles, plot_values_cleaned, color=colors[i], linestyle=line_styles[i], linewidth=line_widths[i], label=entity_names[i])
+        ax.fill(angles, plot_values_cleaned, color=colors[i], alpha=fill_alphas[i])
+
+    # Labels and Legend
+    if metric_labels_override:
+        x_tick_labels = [metric_labels_override.get(m, m.replace('_', ' ').title()) for m in metric_columns]
+    else:
+        x_tick_labels = [m.replace('_', ' ').title() for m in metric_columns]
+    
+    ax.set_xticks(angles[:-1])
+    ax.set_xticklabels(x_tick_labels)
+    
+    if normalize:
+        ax.set_yticks(np.linspace(0, 1, 5))
+        ax.set_ylim(0, 1.05)
+    # Else: let matplotlib auto-scale for non-normalized data or define custom logic
+
+    ax.set_title(title, size=15, y=1.1)
+
+    legend_params = legend_kwargs if legend_kwargs is not None else {'loc': 'upper right', 'bbox_to_anchor': (0.1, 0.1)}
+    ax.legend(**legend_params)
+
+    if output_file:
+        try:
+            fig.savefig(output_file, dpi=dpi, bbox_inches='tight')
+        except Exception as e:
+            print(f"Error saving figure to {output_file}: {e}")
+
+    return fig

--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -391,7 +391,6 @@ def create_dashboard(
                     entity_names=entity_names_list,
                     title="Top Players by Versatility", # Same title as before
                     output_file=output_file
-                    # normalize=True is the default in plot_radar_chart.
                     # create_radar_comparison also defaulted to normalize=True.
                 )
                 created_files.append(output_file)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -238,7 +238,7 @@ class TestPlotRadarChart(unittest.TestCase):
         plt.close('all') # Ensure any partial fig is closed
 
         # DataFrame with more than one row
-        df_multi_row = pd.concat([data_frames[0], data_frames[0]], ignore_index=True) # Changed from append to concat
+        df_multi_row = pd.concat([data_frames[0], data_frames[0]], ignore_index=True)
         multi_row_dfs = [df_multi_row] + data_frames[1:]
         with self.assertRaisesRegex(ValueError, f"DataFrame for entity '{entity_names[0]}' must have exactly one row."):
             plot_radar_chart(

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -21,7 +21,7 @@ def _create_sample_radar_data(num_entities=2, num_metrics=3, custom_metrics=None
     if custom_metrics:
         metric_columns = custom_metrics
         if custom_values and isinstance(custom_values[0], dict): # if values are dicts, num_metrics is from keys
-             num_metrics = len(custom_values[0].keys())
+            num_metrics = len(custom_values[0].keys())
         else: # if values are lists, num_metrics is from length of list
             num_metrics = len(custom_metrics)
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,302 @@
+import unittest
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+from src.utils.visualization import plot_radar_chart
+
+# Helper function for sample data
+def _create_sample_radar_data(num_entities=2, num_metrics=3, custom_metrics=None, custom_values=None):
+    """
+    Creates sample data for radar chart tests.
+    custom_metrics: Optional list of metric names.
+    custom_values: Optional list of lists/dicts for entity data.
+                   If provided, num_entities and num_metrics might be overridden by its structure.
+    """
+    if custom_values:
+        num_entities = len(custom_values)
+    
+    entity_names = [f"Player {i+1}" for i in range(num_entities)]
+
+    if custom_metrics:
+        metric_columns = custom_metrics
+        if custom_values and isinstance(custom_values[0], dict): # if values are dicts, num_metrics is from keys
+             num_metrics = len(custom_values[0].keys())
+        else: # if values are lists, num_metrics is from length of list
+            num_metrics = len(custom_metrics)
+
+    elif custom_values and isinstance(custom_values[0], dict):
+        metric_columns = list(custom_values[0].keys())
+        num_metrics = len(metric_columns)
+    elif custom_values and isinstance(custom_values[0], list):
+        num_metrics = len(custom_values[0])
+        metric_columns = [f"Metric_{chr(65+j)}" for j in range(num_metrics)]
+    else:
+        metric_columns = [f"Metric_{chr(65+j)}" for j in range(num_metrics)]
+
+    data_frames = []
+    if custom_values:
+        for i in range(num_entities):
+            if isinstance(custom_values[i], dict):
+                data = custom_values[i]
+            else: # Assuming list of values in order of metric_columns
+                data = {metric_columns[j]: custom_values[i][j] for j in range(len(custom_values[i]))}
+            data_frames.append(pd.DataFrame([data]))
+    else:
+        for _ in range(num_entities):
+            data = {col: np.random.rand() * 100 for col in metric_columns}
+            data_frames.append(pd.DataFrame([data]))
+            
+    return data_frames, entity_names, metric_columns
+
+class TestPlotRadarChart(unittest.TestCase):
+
+    def tearDown(self):
+        """Close all Matplotlib figures after each test."""
+        plt.close('all')
+
+    def test_basic_chart_creation(self):
+        """Test basic chart creation with minimal valid inputs."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(num_entities=3, num_metrics=4)
+        
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Basic Test Chart"
+            )
+            self.assertIsInstance(fig, plt.Figure)
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+
+    def test_normalization_standard_and_inverted(self):
+        """Test with standard and inverted normalization."""
+        metric_names = ["Attack", "Defense", "Speed", "Errors"]
+        player_data = [
+            {"Attack": 80, "Defense": 60, "Speed": 90, "Errors": 5},
+            {"Attack": 70, "Defense": 70, "Speed": 60, "Errors": 10},
+            {"Attack": 90, "Defense": 50, "Speed": 75, "Errors": 2},
+        ]
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(
+            custom_metrics=metric_names, custom_values=player_data
+        )
+        
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Normalization Test (Standard & Inverted)",
+                normalize=True,
+                normalization_specs={'Errors': 'inverted', 'Speed': 'standard'}
+            )
+            self.assertIsInstance(fig, plt.Figure)
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly during normalization test: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+
+    def test_normalization_same_min_max(self):
+        """Test normalization when all players have the same value for a metric."""
+        metric_names = ["Consistency", "Effort", "Skill"]
+        player_data = [
+            {"Consistency": 75, "Effort": 80, "Skill": 90},
+            {"Consistency": 75, "Effort": 70, "Skill": 85},
+            {"Consistency": 75, "Effort": 90, "Skill": 80},
+        ]
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(
+            custom_metrics=metric_names, custom_values=player_data
+        )
+        
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Same Min-Max Normalization Test",
+                normalize=True
+            )
+            self.assertIsInstance(fig, plt.Figure)
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly during same min-max normalization test: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+
+    def test_output_file_creation(self):
+        """Test chart output to a file."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data()
+        output_file_path = "test_radar_chart_output.png"
+
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="File Output Test",
+                output_file=output_file_path
+            )
+            self.assertIsInstance(fig, plt.Figure)
+            self.assertTrue(os.path.exists(output_file_path))
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly during file output test: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+            if os.path.exists(output_file_path):
+                os.remove(output_file_path)
+                
+    def test_metric_labels_override(self):
+        """Test overriding metric labels."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(num_metrics=3)
+        labels_override = {
+            metric_columns[0]: "Custom Label 1",
+            metric_columns[1]: "Super Metric B",
+        }
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Metric Labels Override Test",
+                metric_labels_override=labels_override
+            )
+            self.assertIsInstance(fig, plt.Figure)
+            # Direct check of tick labels is complex and brittle.
+            # For this test, error-free execution with the override is the main check.
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly during metric labels override test: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+
+    def test_plot_on_existing_axes(self):
+        """Test plotting on an existing Matplotlib Axes object."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data()
+        
+        fig_created, ax_created = plt.subplots(subplot_kw={'polar': True}, figsize=(8,8))
+        
+        returned_fig = None
+        try:
+            returned_fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Existing Axes Test",
+                ax=ax_created
+            )
+            self.assertIsInstance(returned_fig, plt.Figure)
+            self.assertEqual(returned_fig, fig_created, "Should return the same figure object it plotted on.")
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly when plotting on existing axes: {e}")
+        finally:
+            # The tearDown method will close fig_created if returned_fig is the same.
+            # If they are different for some reason (which would be a failure), close both.
+            if returned_fig and returned_fig is not fig_created:
+                 plt.close(returned_fig)
+            if fig_created: # fig_created will always exist
+                 plt.close(fig_created)
+
+
+    def test_input_validation_errors(self):
+        """Test for expected ValueError exceptions with invalid inputs."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(num_entities=2, num_metrics=3)
+
+        # Mismatch in length between data_frames and entity_names
+        with self.assertRaisesRegex(ValueError, "Length of data_frames must match length of entity_names"):
+            plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names[:1], # One less entity name
+                title="Error Test"
+            )
+        plt.close('all') # Ensure any partial fig is closed
+
+        # Metric in metric_columns not present in one of the data_frames
+        df_missing_metric = [data_frames[0].copy()]
+        df_missing_metric[0].drop(columns=[metric_columns[0]], inplace=True)
+        
+        faulty_data_frames = [df_missing_metric[0]] + data_frames[1:]
+
+        with self.assertRaisesRegex(ValueError, f"Metric '{metric_columns[0]}' not found in DataFrame for entity '{entity_names[0]}'"):
+             plot_radar_chart(
+                data_frames=faulty_data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Error Test Metric Missing"
+            )
+        plt.close('all') # Ensure any partial fig is closed
+
+        # DataFrame with more than one row
+        df_multi_row = pd.concat([data_frames[0], data_frames[0]], ignore_index=True) # Changed from append to concat
+        multi_row_dfs = [df_multi_row] + data_frames[1:]
+        with self.assertRaisesRegex(ValueError, f"DataFrame for entity '{entity_names[0]}' must have exactly one row."):
+            plot_radar_chart(
+                data_frames=multi_row_dfs,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Error Test Multi-Row DF"
+            )
+        plt.close('all')
+        
+        # Non-polar axes provided
+        fig_non_polar, ax_non_polar = plt.subplots()
+        with self.assertRaisesRegex(ValueError, "Provided 'ax' must be a Matplotlib polar Axes object."):
+            plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                ax=ax_non_polar
+            )
+        plt.close(fig_non_polar)
+        plt.close('all')
+
+
+    def test_custom_styling(self):
+        """Test with custom styling options."""
+        data_frames, entity_names, metric_columns = _create_sample_radar_data(num_entities=2, num_metrics=4)
+        
+        custom_colors = ['#FF5733', '#33FF57'] # Bright orange and green
+        custom_line_styles = ['--', ':']
+        custom_line_widths = [2.5, 1.0]
+        custom_fill_alphas = [0.25, 0.05]
+        custom_fig_size = (12, 12)
+        custom_legend_kwargs = {'loc': 'lower left', 'fontsize': 'small'}
+
+        fig = None
+        try:
+            fig = plot_radar_chart(
+                data_frames=data_frames,
+                metric_columns=metric_columns,
+                entity_names=entity_names,
+                title="Custom Styling Test",
+                fig_size=custom_fig_size,
+                colors=custom_colors,
+                line_styles=custom_line_styles,
+                line_widths=custom_line_widths,
+                fill_alphas=custom_fill_alphas,
+                legend_kwargs=custom_legend_kwargs
+            )
+            self.assertIsInstance(fig, plt.Figure)
+            # Basic check for custom figure size (approximate due to layout adjustments)
+            # self.assertAlmostEqual(fig.get_size_inches()[0], custom_fig_size[0], delta=0.5)
+            # self.assertAlmostEqual(fig.get_size_inches()[1], custom_fig_size[1], delta=0.5)
+            # More detailed checks would involve inspecting artists, which is complex.
+        except Exception as e:
+            self.fail(f"plot_radar_chart raised an exception unexpectedly during custom styling test: {e}")
+        finally:
+            if fig:
+                plt.close(fig)
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
This commit introduces a new, more flexible `plot_radar_chart` function in `src/utils/visualization.py` to replace the previous `create_radar_comparison` and `create_shooting_profile_radar` functions.

Key changes:
- Added `plot_radar_chart` with enhanced features:
    - Accepts a list of single-row DataFrames and corresponding entity names.
    - Supports flexible normalization, including per-metric 'inverted' normalization.
    - Allows customization of styling (colors, line styles, figure size, etc.).
    - Can plot on an existing Matplotlib Axes object.
- Updated `create_dashboard` in `src/utils/visualization.py` and `create_shooting_metrics_dashboard` in `src/utils/shooting_visualizations.py` to use the new `plot_radar_chart` function.
- Added comprehensive unit tests for `plot_radar_chart` in `tests/test_visualization.py`, covering various scenarios including normalization, file output, custom styling, and input validation. All tests pass.
- Marked the old `create_radar_comparison` and `create_shooting_profile_radar` functions as deprecated with warnings.
- Improved comments and ensured docstrings and type hints are up-to-date for the new and modified functions.